### PR TITLE
Remove deprecated capabilities of mod_data (MDL-84267)

### DIFF
--- a/assets/roles/bookit_bookingperson.xml
+++ b/assets/roles/bookit_bookingperson.xml
@@ -222,7 +222,6 @@
 		<inherit>mod/choice:view</inherit>
 		<inherit>mod/data:addinstance</inherit>
 		<inherit>mod/data:approve</inherit>
-		<inherit>mod/data:comment</inherit>
 		<inherit>mod/data:exportallentries</inherit>
 		<inherit>mod/data:exportentry</inherit>
 		<inherit>mod/data:exportownentry</inherit>

--- a/assets/roles/bookit_examiner.xml
+++ b/assets/roles/bookit_examiner.xml
@@ -249,7 +249,6 @@
 		<inherit>mod/choice:view</inherit>
 		<inherit>mod/data:addinstance</inherit>
 		<inherit>mod/data:approve</inherit>
-		<inherit>mod/data:comment</inherit>
 		<inherit>mod/data:exportallentries</inherit>
 		<inherit>mod/data:exportentry</inherit>
 		<inherit>mod/data:exportownentry</inherit>

--- a/assets/roles/bookit_observer.xml
+++ b/assets/roles/bookit_observer.xml
@@ -250,7 +250,6 @@
 		<inherit>mod/choice:view</inherit>
 		<inherit>mod/data:addinstance</inherit>
 		<inherit>mod/data:approve</inherit>
-		<inherit>mod/data:comment</inherit>
 		<inherit>mod/data:exportallentries</inherit>
 		<inherit>mod/data:exportentry</inherit>
 		<inherit>mod/data:exportownentry</inherit>

--- a/assets/roles/bookit_serviceteam.xml
+++ b/assets/roles/bookit_serviceteam.xml
@@ -262,7 +262,6 @@
 		<inherit>mod/choice:view</inherit>
 		<inherit>mod/data:addinstance</inherit>
 		<inherit>mod/data:approve</inherit>
-		<inherit>mod/data:comment</inherit>
 		<inherit>mod/data:exportallentries</inherit>
 		<inherit>mod/data:exportentry</inherit>
 		<inherit>mod/data:exportownentry</inherit>

--- a/assets/roles/bookit_supportonsite.xml
+++ b/assets/roles/bookit_supportonsite.xml
@@ -250,7 +250,6 @@
 		<inherit>mod/choice:view</inherit>
 		<inherit>mod/data:addinstance</inherit>
 		<inherit>mod/data:approve</inherit>
-		<inherit>mod/data:comment</inherit>
 		<inherit>mod/data:exportallentries</inherit>
 		<inherit>mod/data:exportentry</inherit>
 		<inherit>mod/data:exportownentry</inherit>


### PR DESCRIPTION
The capability mod/data:comment was deprecated in Moodle 5.0 so that installing this plugin on said version throws an E_WARNING. As the capability has no effect it can be removed without any side effects.

See https://moodle.atlassian.net/browse/MDL-84267 for details